### PR TITLE
Add Jest tests for random question index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Drinkify
+
+## Running Tests
+
+1. Install dependencies (Jest):
+   ```bash
+   npm install
+   ```
+
+2. Execute the test suite:
+   ```bash
+   npm test
+   ```

--- a/js/script.js
+++ b/js/script.js
@@ -217,3 +217,8 @@ function showResult() {
 
     scoreTextEl.innerHTML = `<span>${challenge}</span>`;
 }
+
+// Export para testes em ambiente Node
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = { getRandomQuestionIndex };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "drinkify",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/getRandomQuestionIndex.test.js
+++ b/tests/getRandomQuestionIndex.test.js
@@ -1,0 +1,35 @@
+class StorageMock {
+  constructor() { this.store = {}; }
+  getItem(key) { return this.store[key] || null; }
+  setItem(key, value) { this.store[key] = String(value); }
+  removeItem(key) { delete this.store[key]; }
+  clear() { this.store = {}; }
+}
+
+describe('getRandomQuestionIndex', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    global.sessionStorage = new StorageMock();
+    global.questions = Array.from({ length: 3 }, (_, i) => ({ numb: i }));
+  });
+
+  test('returns unique indices until questions are exhausted', () => {
+    const { getRandomQuestionIndex } = require('../js/script.js');
+    const seen = new Set();
+    for (let i = 0; i < global.questions.length; i++) {
+      const idx = getRandomQuestionIndex();
+      expect(idx).not.toBeNull();
+      expect(seen.has(idx)).toBe(false);
+      seen.add(idx);
+    }
+  });
+
+  test('returns null when no questions remain', () => {
+    const { getRandomQuestionIndex } = require('../js/script.js');
+    // Exhaust questions
+    for (let i = 0; i < global.questions.length; i++) {
+      getRandomQuestionIndex();
+    }
+    expect(getRandomQuestionIndex()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add npm setup for Jest
- export `getRandomQuestionIndex` from `script.js`
- add unit tests for random question picker
- document test steps in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684066009d30832aa01efeba6be65e9d