### PR TITLE
Fix typo in resetQuiz comment

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -99,7 +99,7 @@ function startQuiz() {
 window.startQuiz = startQuiz;
 
 /* ----------------------------------------
-   6) Função para “resetar” apenas quiz/resulBox (não reseta no_repeat)
+   6) Função para “resetar” apenas quiz/resultBox (não reseta no_repeat)
    ---------------------------------------- */
 function resetQuiz() {
     // Limpa quaisquer timers pendentes


### PR DESCRIPTION
## Summary
- fix comment in `js/script.js` referencing `quiz/resultBox`

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684065ffd8fc832ab5f56d177cf61b0b